### PR TITLE
GET /api/livestream/searchのN + 1を解消

### DIFF
--- a/home/isucon/webapp/ruby/app.rb
+++ b/home/isucon/webapp/ruby/app.rb
@@ -314,24 +314,20 @@ module Isupipe
           if key_tag_name != ''
             # タグによる取得
             tag_id_list = tx.xquery('SELECT id FROM tags WHERE name = ?', key_tag_name, as: :array).map(&:first)
-            tx.xquery('SELECT * FROM livestream_tags WHERE tag_id IN (?) ORDER BY livestream_id DESC', tag_id_list).map do |key_tagged_livestream|
-              tx.xquery('SELECT * FROM livestreams WHERE id = ?', key_tagged_livestream.fetch(:livestream_id)).first
-            end
-
             tx.xquery(
               `
-              SELECT
-                livestreams.*, livestream_tags.*
-              FROM
-                livestreams
-              JOIN
-                livestream_tags ON livestreams.id = livestream_tags.livestream_id
-              WHERE
-                livestream_tags.tag_id IN (?)
-              ORDER BY
-                livestreams.id
-              DESC
-              `,  tag_id_list)
+                SELECT
+                  livestreams.*
+                FROM
+                  livestreams
+                JOIN
+                  livestream_tags ON livestreams.id = livestream_tags.livestream_id
+                WHERE
+                  livestream_tags.tag_id IN (?)
+                ORDER BY
+                  livestreams.id DESC
+                LIMIT 1;
+              `, tag_id_list
             )
           else
             # 検索条件なし

--- a/home/isucon/webapp/sql/initdb.d/10_schema.sql
+++ b/home/isucon/webapp/sql/initdb.d/10_schema.sql
@@ -59,7 +59,7 @@ CREATE TABLE `livestream_tags` (
   `livestream_id` BIGINT NOT NULL,
   `tag_id` BIGINT NOT NULL
 ) ENGINE=InnoDB CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;
-CREATE INDEX livestream_livestream_tags ON livestream_tags(`livestream_id`);
+CREATE INDEX index_livestream_tags ON livestream_tags(`livestream_id`, `tag_id`);
 
 -- ライブ配信視聴履歴
 CREATE TABLE `livestream_viewers_history` (


### PR DESCRIPTION
## ボトルネックとなっているSQL
```
# Query 1: 30.86 QPS, 0.88x concurrency, ID 0xD6032FE08E1FE706A928B8B7CBA06B85 at byte 64210164
# This item is included in the report because it matches --limit.
# Scores: V/M = 16.53
# Time range: 2023-11-25T04:36:10 to 2023-11-25T04:44:28
# Attribute    pct   total     min     max     avg     95%  stddev  median
# ============ === ======= ======= ======= ======= ======= ======= =======
# Count          3   15366
# Exec time     27    438s    71us     27s    29ms     3ms   687ms   185us
# Lock time      0    24ms       0     2ms     1us     1us    26us     1us
# Rows sent      3  15.01k       1       1       1       1       0       1
# Rows examine   0  15.01k       1       1       1       1       0       1
# Query size     0 644.64k      40      43   42.96   42.48    0.39   42.48
# String:
# Databases    isupipe
# Hosts        localhost
# Users        isucon
# Query_time distribution
#   1us
#  10us  ############################
# 100us  ################################################################
#   1ms  #######################
#  10ms  #
# 100ms  #
#    1s  #
#  10s+  #
# Tables
#    SHOW TABLE STATUS FROM `isupipe` LIKE 'livestreams'\G
#    SHOW CREATE TABLE `isupipe`.`livestreams`\G
# EXPLAIN /*!50100 PARTITIONS*/
SELECT * FROM livestreams WHERE id = '7529'\G
```

## EXPLAIN
```
mysql> EXPLAIN SELECT livestreams.* FROM livestreams JOIN livestream_tags ON livestreams.id = livestream_tags.livestream_id WHERE livestream_tags.tag_id IN (1, 2, 3) ORDER BY livestreams.id DESC LIMIT 1;
ERROR 2013 (HY000): Lost connection to MySQL server during query
No connection. Trying to reconnect...
Connection id:    8
Current database: isupipe

+----+-------------+-----------------+------------+--------+----------------------------+---------+---------+---------------------------------------+-------+----------+----------------------------------------------+
| id | select_type | table           | partitions | type   | possible_keys              | key     | key_len | ref                                   | rows  | filtered | Extra                                        |
+----+-------------+-----------------+------------+--------+----------------------------+---------+---------+---------------------------------------+-------+----------+----------------------------------------------+
|  1 | SIMPLE      | livestream_tags | NULL       | ALL    | livestream_livestream_tags | NULL    | NULL    | NULL                                  | 11137 |    30.00 | Using where; Using temporary; Using filesort |
|  1 | SIMPLE      | livestreams     | NULL       | eq_ref | PRIMARY                    | PRIMARY | 8       | isupipe.livestream_tags.livestream_id |     1 |   100.00 | NULL                                         |
+----+-------------+-----------------+------------+--------+----------------------------+---------+---------+---------------------------------------+-------+----------+----------------------------------------------+
2 rows in set, 1 warning (0.02 sec)

mysql> ALTER TABLE livestream_tags ADD INDEX index_tag_id(tag_id);
Query OK, 0 rows affected (0.13 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> EXPLAIN SELECT livestreams.* FROM livestreams JOIN livestream_tags ON livestreams.id = livestream_tags.livestream_id WHERE livestream_tags.tag_id IN (1, 2, 3) ORDER BY livestreams.id DESC LIMIT 1;
+----+-------------+-----------------+------------+--------+-----------------------------------------+--------------+---------+---------------------------------------+------+----------+--------------------------------------------------------+
| id | select_type | table           | partitions | type   | possible_keys                           | key          | key_len | ref                                   | rows | filtered | Extra                                                  |
+----+-------------+-----------------+------------+--------+-----------------------------------------+--------------+---------+---------------------------------------+------+----------+--------------------------------------------------------+
|  1 | SIMPLE      | livestream_tags | NULL       | range  | livestream_livestream_tags,index_tag_id | index_tag_id | 8       | NULL                                  |  348 |   100.00 | Using index condition; Using temporary; Using filesort |
|  1 | SIMPLE      | livestreams     | NULL       | eq_ref | PRIMARY                                 | PRIMARY      | 8       | isupipe.livestream_tags.livestream_id |    1 |   100.00 | NULL                                                   |
+----+-------------+-----------------+------------+--------+-----------------------------------------+--------------+---------+---------------------------------------+------+----------+--------------------------------------------------------+
2 rows in set, 1 warning (0.00 sec)

mysql> DROP INDEX index_tag_id ON livestream_tags;
Query OK, 0 rows affected (0.01 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> ALTER TABLE livestream_tags ADD INDEX index_livestream_id_tag_id(livestream_id, tag_id);
Query OK, 0 rows affected (0.13 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> EXPLAIN SELECT livestreams.* FROM livestreams JOIN livestream_tags ON livestreams.id = livestream_tags.livestream_id WHERE livestream_tags.tag_id IN (1, 2, 3) ORDER BY livestreams.id DESC LIMIT 1;
+----+-------------+-----------------+------------+-------+-------------------------------------------------------+----------------------------+---------+------------------------+------+----------+---------------------+
| id | select_type | table           | partitions | type  | possible_keys                                         | key                        | key_len | ref                    | rows | filtered | Extra               |
+----+-------------+-----------------+------------+-------+-------------------------------------------------------+----------------------------+---------+------------------------+------+----------+---------------------+
|  1 | SIMPLE      | livestreams     | NULL       | index | PRIMARY                                               | PRIMARY                    | 8       | NULL                   |    2 |   100.00 | Backward index scan |
|  1 | SIMPLE      | livestream_tags | NULL       | ref   | livestream_livestream_tags,index_livestream_id_tag_id | livestream_livestream_tags | 8       | isupipe.livestreams.id |    1 |    30.00 | Using where         |
+----+-------------+-----------------+------------+-------+-------------------------------------------------------+----------------------------+---------+------------------------+------+----------+---------------------+
2 rows in set, 1 warning (0.00 sec)

mysql>
```